### PR TITLE
Reduce docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,44 @@
-FROM python:3
-WORKDIR /app
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Builder Image
+#
+FROM python:3-alpine AS builder
+
+ENV PATH="/app/venv/bin:$PATH"
+
+WORKDIR /app/
 
 COPY requirements.txt requirements.txt
-RUN pip install -r requirements.txt --no-cache-dir
+
+RUN \
+    echo "**** Install build packages. ****" && \
+        apk --no-cache upgrade && \
+        apk add --no-cache \
+            gcc \
+            musl-dev \
+            python3-dev \
+            alpine-sdk \
+            libffi-dev && \
+    echo "**** Build registry ui ****" && \
+        python3 -m venv --clear venv && \
+        pip install -r requirements.txt --no-cache-dir
 
 COPY src src
 COPY templates templates
 COPY static static
 
-# Run sanic in production mode
-ENV APP_DEBUG false
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Runtime Image
+#
+FROM python:3-alpine AS final
+
+COPY --from=builder /app /app
+
+WORKDIR /app/
+
+ENV \
+    PATH="/app/venv/bin:$PATH" \
+    APP_DEBUG=false
 
 EXPOSE 8000
+
 ENTRYPOINT [ "python3", "-m", "src.main" ]


### PR DESCRIPTION
When pulling the docker image I noticed that the size of the image was 967mb (after extracting on the host).

This I think could be reduced by switching to a multi stage build & using alpine as the base image.
The multi stage build uses a virtualenv which creates a isolated directory containing the Python dependencies.
After installing the dependencies & copying over the needed files (src, templates & static directories) the `/app` directory is copied to the runtime image.

The final image is 94mb.