### PR TITLE
Manifest application/vnd.oci.image.manifest.v1+json

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -61,7 +61,7 @@ class DockerApiV2():
       headers={'Accept': 'application/vnd.docker.distribution.manifest.v2+json,application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.oci.image.manifest.v1+json'},
       creds=creds
     )
-    if res.get('mediaType') == 'application/vnd.docker.distribution.manifest.v2+json':
+    if res.get('manifests') is None:
       return [res]
     else:
       return res['manifests']

--- a/src/api.py
+++ b/src/api.py
@@ -23,7 +23,7 @@ class DockerApiV2():
       self.base_url = base_url
 
     self.headers = {
-      'Accept': 'application/vnd.docker.distribution.manifest.v2+json'
+      'Accept': 'application/vnd.docker.distribution.manifest.v2+json,application/vnd.oci.image.manifest.v1+json'
     }
     self.headers.update(ApiCredentials(username, password).headers)
     self.session = None
@@ -58,7 +58,7 @@ class DockerApiV2():
   async def get_manifest_list(self, repo, tag, creds=None) -> List[dict]:
     res = await self._get(
       f'/v2/{repo}/manifests/{tag}',
-      headers={'Accept': 'application/vnd.docker.distribution.manifest.v2+json,application/vnd.docker.distribution.manifest.list.v2+json'},
+      headers={'Accept': 'application/vnd.docker.distribution.manifest.v2+json,application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.oci.image.manifest.v1+json'},
       creds=creds
     )
     if res.get('mediaType') == 'application/vnd.docker.distribution.manifest.v2+json':


### PR DESCRIPTION
According to you comment in #3 I created the modifcations you suggested and they nearly worked. I discovered that the OCI images sadly do not have the 'mediaType' field. So I had to change the differentiation criterion in get_manifest_list. Let me know if you are happy with how it is done now.

I tested the changes on a registry which has normal docker images, docker multi arch images and OCI images, which should cover it all.