### PR TITLE
Dependency Fix & 0 Tag Fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ aiohttp
 Jinja2
 loguru
 python-dateutil
-sanic
+sanic==22.9.1

--- a/src/data_fetch.py
+++ b/src/data_fetch.py
@@ -56,7 +56,7 @@ async def fetch_repositories(api: DockerApiV2, creds=None):
   return [
     {
       'repo': repo,
-      'tag_count': len(tag_list)
+      'tag_count': 0 if tag_list is None else len(tag_list)
     }
     for repo, tag_list in zip(repositories, tags)
   ]
@@ -64,6 +64,8 @@ async def fetch_repositories(api: DockerApiV2, creds=None):
 
 async def fetch_tags(api: DockerApiV2, repo, creds=None):
   tags = await api.get_tags(repo, creds=creds)
+  if tags is None:
+    return []
 
   # fetch more details for each tag
   images = await asyncio.gather(*[fetch_image(api, repo, t, creds=creds) for t in tags])


### PR DESCRIPTION
This pull request contains solutions for 2 problems:

1. The sanic dependency has changed which resulted in the following runtime error:

    ```
    Sanic app name 'registry-ui' not found.
    App instantiation must occur outside if __name__ == '__main__' block or by using an AppLoader.
    See https://sanic.dev/en/guide/deployment/app-loader.html for more details.
    Traceback (most recent call last):
      File "/usr/local/lib/python3.10/site-packages/sanic/app.py", line 1491, in get_app
        return cls._app_registry[name]
    KeyError: 'registry-ui'
    ```
    Therefore I temporarily pinned the dependency to the last working version.
2. I added some code to handle images with 0 tags, this previously resulted in some exceptions.

Let me know if you would like me to change anything.

P.S. I recently learned that it is fairly easy to delete tags from a v2 registry (see [here](https://github.com/byrnedo/docker-reg-tool)). Would you be interested in having a button in the ui to do so?